### PR TITLE
Clean up client/hub

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,8 +22,6 @@ import (
 
 // Client is a middleman between the websocket connection and the hub.
 type Client struct {
-	hub *Hub
-
 	// The server-sent event name.
 	event string
 
@@ -33,11 +31,9 @@ type Client struct {
 
 // registerClient handles SSE intitiation requests from the peer.
 func registerClient(hub *Hub, c *gin.Context) {
-	client := &Client{hub: hub, event: "message", send: make(chan []byte, 256)}
-	client.hub.register <- client
-	defer func() {
-		client.hub.unregister <- client
-	}()
+	client := &Client{event: "message", send: make(chan []byte, 256)}
+	hub.Register(client)
+	defer hub.Unregister(client)
 
 	c.Stream(func(w io.Writer) bool {
 		if message, ok := <-client.send; ok {

--- a/client.go
+++ b/client.go
@@ -39,6 +39,11 @@ func (c *Client) Send(s string) bool {
 	}
 }
 
+// Halt further communications to this client by closing its send channel.
+func (c *Client) Halt() {
+	close(c.send)
+}
+
 // registerClient handles SSE intitiation requests from the peer.
 func registerClient(hub *Hub, c *gin.Context) {
 	client := &Client{event: "message", send: make(chan string, 256)}

--- a/client.go
+++ b/client.go
@@ -12,7 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Portions copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
+
+import (
+	"io"
+	"log"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	// Time allowed to write a message to the peer.
+	// writeWait = 10 * time.Second
+
+	// Time allowed to read the next pong message from the peer.
+	pongWait = 60 * time.Second
+
+	// Send pings to peer with this period. Must be less than pongWait.
+	pingPeriod = (pongWait * 9) / 10
+
+	// Maximum message size allowed from peer.
+	// maxMessageSize = 512
+)
 
 // Client is a middleman between the websocket connection and the hub.
 type Client struct {
@@ -36,6 +62,50 @@ func (c *Client) Send(s string) bool {
 // Halt further communications to this client by closing its send channel.
 func (c *Client) Halt() {
 	close(c.send)
+}
+
+func (c *Client) writePump(ctx *gin.Context) {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		// c.conn.Close()
+	}()
+	ctx.Stream(func(w io.Writer) bool {
+		select {
+		case message, ok := <-c.send:
+			// c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				// The hub closed the channel.
+				// c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return false
+			}
+
+			/*w, err := c.conn.NextWriter(websocket.TextMessage)
+			if err != nil {
+				return false
+			}*/
+			ctx.SSEvent(c.event, message)
+
+			// Add queued chat messages to the current websocket message.
+			/*n := len(c.send)
+			for i := 0; i < n; i++ {
+				w.Write(newline)
+				ctx.SSEvent(c.event, <-c.send)
+			}*/
+
+			/*if err := w.Close(); err != nil {
+				return false
+			}*/
+		case <-ticker.C:
+			log.Println("Keeping alive")
+			ctx.SSEvent("", "Keep alive")
+			//c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			/*if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return false
+			}*/
+		}
+		return true
+	})
 }
 
 func newClient(e string) *Client {

--- a/client.go
+++ b/client.go
@@ -26,18 +26,18 @@ type Client struct {
 	event string
 
 	// Buffered channel of outbound messages.
-	send chan []byte
+	send chan string
 }
 
 // registerClient handles SSE intitiation requests from the peer.
 func registerClient(hub *Hub, c *gin.Context) {
-	client := &Client{event: "message", send: make(chan []byte, 256)}
+	client := &Client{event: "message", send: make(chan string, 256)}
 	hub.Register(client)
 	defer hub.Unregister(client)
 
 	c.Stream(func(w io.Writer) bool {
 		if message, ok := <-client.send; ok {
-			c.SSEvent(client.event, string(message))
+			c.SSEvent(client.event, message)
 			return true
 		}
 		return false

--- a/client.go
+++ b/client.go
@@ -14,12 +14,6 @@
 
 package main
 
-import (
-	"io"
-
-	"github.com/gin-gonic/gin"
-)
-
 // Client is a middleman between the websocket connection and the hub.
 type Client struct {
 	// The server-sent event name.
@@ -44,17 +38,9 @@ func (c *Client) Halt() {
 	close(c.send)
 }
 
-// registerClient handles SSE intitiation requests from the peer.
-func registerClient(hub *Hub, c *gin.Context) {
-	client := &Client{event: "message", send: make(chan string, 256)}
-	hub.Register(client)
-	defer hub.Unregister(client)
-
-	c.Stream(func(w io.Writer) bool {
-		if message, ok := <-client.send; ok {
-			c.SSEvent(client.event, message)
-			return true
-		}
-		return false
-	})
+func newClient(e string) *Client {
+	return &Client{
+		event: e,
+		send:  make(chan string, 256),
+	}
 }

--- a/client.go
+++ b/client.go
@@ -29,6 +29,16 @@ type Client struct {
 	send chan string
 }
 
+// Send to the client, returning whether the operation was successful.
+func (c *Client) Send(s string) bool {
+	select {
+	case c.send <- s:
+		return true
+	default:
+		return false
+	}
+}
+
 // registerClient handles SSE intitiation requests from the peer.
 func registerClient(hub *Hub, c *gin.Context) {
 	client := &Client{event: "message", send: make(chan string, 256)}

--- a/hub.go
+++ b/hub.go
@@ -52,12 +52,12 @@ func (h *Hub) run() {
 		case client := <-h.unregister:
 			if _, ok := h.clients[client]; ok {
 				delete(h.clients, client)
-				close(client.send)
+				client.Halt()
 			}
 		case message := <-h.broadcast:
 			for client := range h.clients {
 				if !client.Send(message) {
-					close(client.send)
+					client.Halt()
 					delete(h.clients, client)
 				}
 			}

--- a/hub.go
+++ b/hub.go
@@ -8,7 +8,7 @@ package main
 // clients.
 type Hub struct {
 	// Registered clients.
-	clients map[*Client]bool
+	clients map[*Client]struct{}
 
 	// Inbound messages from the clients.
 	broadcast chan []byte
@@ -25,7 +25,7 @@ func newHub() *Hub {
 		broadcast:  make(chan []byte),
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
-		clients:    make(map[*Client]bool),
+		clients:    make(map[*Client]struct{}),
 	}
 }
 
@@ -48,7 +48,7 @@ func (h *Hub) run() {
 	for {
 		select {
 		case client := <-h.register:
-			h.clients[client] = true
+			h.clients[client] = struct{}{}
 		case client := <-h.unregister:
 			if _, ok := h.clients[client]; ok {
 				delete(h.clients, client)

--- a/hub.go
+++ b/hub.go
@@ -11,7 +11,7 @@ type Hub struct {
 	clients map[*Client]struct{}
 
 	// Inbound messages from the clients.
-	broadcast chan []byte
+	broadcast chan string
 
 	// Register requests from the clients.
 	register chan *Client
@@ -22,7 +22,7 @@ type Hub struct {
 
 func newHub() *Hub {
 	return &Hub{
-		broadcast:  make(chan []byte),
+		broadcast:  make(chan string),
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
 		clients:    make(map[*Client]struct{}),
@@ -40,8 +40,8 @@ func (h *Hub) Unregister(c *Client) {
 }
 
 // Broadcast to all clients in the hub.
-func (h *Hub) Broadcast(bb []byte) {
-	h.broadcast <- bb
+func (h *Hub) Broadcast(s string) {
+	h.broadcast <- s
 }
 
 func (h *Hub) run() {

--- a/hub.go
+++ b/hub.go
@@ -56,9 +56,7 @@ func (h *Hub) run() {
 			}
 		case message := <-h.broadcast:
 			for client := range h.clients {
-				select {
-				case client.send <- message:
-				default:
+				if !client.Send(message) {
 					close(client.send)
 					delete(h.clients, client)
 				}

--- a/hub.go
+++ b/hub.go
@@ -29,6 +29,21 @@ func newHub() *Hub {
 	}
 }
 
+// Register a client with the hub.
+func (h *Hub) Register(c *Client) {
+	h.register <- c
+}
+
+// Unregister a client from the hub.
+func (h *Hub) Unregister(c *Client) {
+	h.unregister <- c
+}
+
+// Broadcast to all clients in the hub.
+func (h *Hub) Broadcast(bb []byte) {
+	h.broadcast <- bb
+}
+
 func (h *Hub) run() {
 	for {
 		select {

--- a/hub.go
+++ b/hub.go
@@ -1,4 +1,18 @@
-// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Copyright 2018 Andrew Merenbach
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Portions copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 		log.Println("Received:", sound)
 		if _, ok := sounds[sound]; ok {
 			log.Println("Adding sound to queue:", sound)
-			hub.Broadcast([]byte(sound))
+			hub.Broadcast(sound)
 			c.String(http.StatusOK, "")
 		} else {
 			log.Println("Ignoring unknown sound:", sound)

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 		log.Println("Received:", sound)
 		if _, ok := sounds[sound]; ok {
 			log.Println("Adding sound to queue:", sound)
-			hub.broadcast <- []byte(sound)
+			hub.Broadcast([]byte(sound))
 			c.String(http.StatusOK, "")
 		} else {
 			log.Println("Ignoring unknown sound:", sound)

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 		}
 	})
 	router.GET("/play", func(c *gin.Context) {
-		client := newClient("play")
+		client := newClient()
 		hub.Register(client)
 		defer hub.Unregister(client)
 		client.writePump(c)

--- a/static/main.js
+++ b/static/main.js
@@ -31,6 +31,7 @@
             var eventSource = new EventSource(urlPath);
             eventSource.onopen = () => console.log("EventSource connection to server opened:", urlPath);
             eventSource.onerror = () => console.error("EventSource failed:", urlPath);
+            eventSource.onmessage = (e) => console.log("INFO:", e.data);
             return eventSource;
         }
 
@@ -122,7 +123,7 @@
                     });
 
                     const source = newEventSource("/play");
-                    source.addEventListener("message", function (e) {
+                    source.addEventListener("play", function (e) {
                         console.log("RECV:", e.data);
 
                         var newElement = document.createElement("li");


### PR DESCRIPTION
* Add heartbeat to fix browser timeouts (e.g., 2m in Chrome)
* Improve queue robustness (and use a Map, rather than an Object)
* Refactor Client and Hub to better encapsulate struct contents, remove Websocket features, and hopefully leave just what we need for SSE